### PR TITLE
Add React slot demo skeleton

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended"
+  ],
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "jest": true
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# slots_app
+# Fruit Spin 4x4
+
+This is a small client‑only slot demo built with React and Vite. It displays a 4×4 grid of emoji symbols and highlights winning lines.
+
+## Development
+
+Dependencies are listed in `package.json` but are not installed in this repository. Normally you would run `npm install` then `npm run dev` to start the Vite dev server.
+
+The project includes basic Jest tests for the win‑detection utility:
+
+```
+npm test
+```
+
+Because the Codex environment has no internet access, dependencies cannot be installed here so the build and tests cannot run.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Fruit Spin 4x4</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': 'identity-obj-proxy'
+  },
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "fruit-spin-4x4",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-modal": "^3.16.1",
+    "framer-motion": "^10.16.4"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.8",
+    "@types/react-dom": "^18.2.4",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.5.0",
+    "vite": "^5.2.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.2.1",
+    "eslint": "^8.56.0",
+    "@typescript-eslint/parser": "^6.7.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import SlotGrid from './components/SlotGrid';
+import BetSlider from './components/BetSlider';
+import JackpotModal from './components/JackpotModal';
+import { RTPTracker } from './utils/rtpTracker';
+
+const SYMBOLS = ['🍒', '🍋', '🍊', '🍇', '🍉', '🥝'];
+
+const tracker = new RTPTracker();
+
+function App() {
+  const [balance, setBalance] = useState(300);
+  const [bet, setBet] = useState(1);
+  const [wins, setWins] = useState<string[][]>([]);
+  const [jackpot, setJackpot] = useState<number | null>(null);
+
+  const handleSpin = (grid: string[][], winLines: number[][]) => {
+    const totalWin = winLines.length * bet * 10; // simple payout
+    setBalance((b) => b - bet + totalWin);
+    tracker.record(bet, totalWin);
+    setWins(winLines.map((line) => line.map((i) => grid[Math.floor(i / 4)][i % 4])));
+  };
+
+  return (
+    <div className="app">
+      <h1>Fruit Spin 4x4</h1>
+      <SlotGrid
+        symbols={SYMBOLS}
+        bet={bet}
+        onSpin={handleSpin}
+        onJackpot={(amount) => setJackpot(amount)}
+      />
+      <BetSlider value={bet} onChange={setBet} balance={balance} />
+      <p>Balance: €{balance.toFixed(2)}</p>
+      <p>RTP: {(tracker.rtp * 100).toFixed(2)}%</p>
+      <JackpotModal amount={jackpot} onClose={() => setJackpot(null)} />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/BetSlider.tsx
+++ b/src/components/BetSlider.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface BetSliderProps {
+  value: number;
+  onChange: (v: number) => void;
+  balance: number;
+}
+
+const BetSlider: React.FC<BetSliderProps> = ({ value, onChange, balance }) => {
+  return (
+    <div className="bet-slider">
+      <input
+        type="range"
+        min="0.1"
+        max="5"
+        step="0.1"
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+      />
+      <span>Bet: €{value.toFixed(2)}</span>
+    </div>
+  );
+};
+
+export default BetSlider;

--- a/src/components/JackpotModal.tsx
+++ b/src/components/JackpotModal.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Modal from 'react-modal';
+
+interface JackpotModalProps {
+  amount: number | null;
+  onClose: () => void;
+}
+
+const JackpotModal: React.FC<JackpotModalProps> = ({ amount, onClose }) => {
+  return (
+    <Modal isOpen={amount !== null} onRequestClose={onClose} ariaHideApp={false}>
+      <h2>{amount ? `Jackpot! +€${amount}` : 'Missed'}</h2>
+    </Modal>
+  );
+};
+
+export default JackpotModal;

--- a/src/components/Reel.tsx
+++ b/src/components/Reel.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface ReelProps {
+  symbols: string[];
+}
+
+const Reel: React.FC<ReelProps> = ({ symbols }) => {
+  return (
+    <div className="reel">
+      {symbols.map((sym, idx) => (
+        <div key={idx} className="cell">
+          {sym}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Reel;

--- a/src/components/SlotGrid.tsx
+++ b/src/components/SlotGrid.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import Reel from './Reel';
+import { checkWins } from '../utils/payTable';
+
+interface SlotGridProps {
+  symbols: string[];
+  bet: number;
+  onSpin: (grid: string[][], winLines: number[][]) => void;
+  onJackpot: (amount: number) => void;
+}
+
+const SlotGrid: React.FC<SlotGridProps> = ({ symbols, bet, onSpin, onJackpot }) => {
+  const [grid, setGrid] = useState<string[][]>(Array.from({ length: 4 }, () => Array(4).fill('')));
+  const [spinning, setSpinning] = useState(false);
+
+  const spin = () => {
+    if (spinning) return;
+    setSpinning(true);
+    const newGrid = Array.from({ length: 4 }, () =>
+      Array.from({ length: 4 }, () => symbols[Math.floor(Math.random() * symbols.length)])
+    );
+    setTimeout(() => {
+      setGrid(newGrid);
+      const winLines = checkWins(newGrid);
+      if (Math.random() < 0.05) {
+        const jackpotWin = bet * 100;
+        onJackpot(jackpotWin);
+      }
+      onSpin(newGrid, winLines);
+      setSpinning(false);
+    }, 2000);
+  };
+
+  return (
+    <div className="slot-grid">
+      <div className="reels">
+        {grid.map((col, i) => (
+          <Reel key={i} symbols={col} />
+        ))}
+      </div>
+      <button onClick={spin} disabled={spinning}>
+        {spinning ? 'Spinning...' : 'Spin'}
+      </button>
+    </div>
+  );
+};
+
+export default SlotGrid;

--- a/src/hooks/useSpin.ts
+++ b/src/hooks/useSpin.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { checkWins } from '../utils/payTable';
+
+export function useSpin(symbols: string[], onJackpot: (amount: number) => void) {
+  const [grid, setGrid] = useState<string[][]>(Array.from({ length: 4 }, () => Array(4).fill('')));
+  const [spinning, setSpinning] = useState(false);
+
+  const spin = (bet: number, callback: (g: string[][], wins: number[][]) => void) => {
+    if (spinning) return;
+    setSpinning(true);
+    const newGrid = Array.from({ length: 4 }, () =>
+      Array.from({ length: 4 }, () => symbols[Math.floor(Math.random() * symbols.length)])
+    );
+    setTimeout(() => {
+      setGrid(newGrid);
+      const winLines = checkWins(newGrid);
+      if (Math.random() < 0.05) {
+        onJackpot(bet * 100);
+      }
+      callback(newGrid, winLines);
+      setSpinning(false);
+    }, 2000);
+  };
+
+  return { grid, spinning, spin };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/utils/__tests__/payTable.test.ts
+++ b/src/utils/__tests__/payTable.test.ts
@@ -1,0 +1,31 @@
+import { checkWins } from '../payTable';
+
+test('detects row win', () => {
+  const grid = [
+    ['A', 'A', 'A', 'A'],
+    ['B', 'C', 'D', 'E'],
+    ['B', 'C', 'D', 'E'],
+    ['B', 'C', 'D', 'E']
+  ];
+  expect(checkWins(grid)).toEqual([[0,1,2,3]]);
+});
+
+test('detects column win', () => {
+  const grid = [
+    ['A', 'B', 'C', 'D'],
+    ['A', 'B', 'C', 'D'],
+    ['A', 'B', 'C', 'D'],
+    ['A', 'B', 'C', 'D']
+  ];
+  expect(checkWins(grid)).toContainEqual([0,4,8,12]);
+});
+
+test('detects diagonal win', () => {
+  const grid = [
+    ['A', 'B', 'C', 'D'],
+    ['E', 'A', 'F', 'G'],
+    ['H', 'I', 'A', 'J'],
+    ['K', 'L', 'M', 'A']
+  ];
+  expect(checkWins(grid)).toContainEqual([0,5,10,15]);
+});

--- a/src/utils/payTable.ts
+++ b/src/utils/payTable.ts
@@ -1,0 +1,24 @@
+export function checkWins(grid: string[][]): number[][] {
+  const lines: number[][] = [];
+  // rows
+  for (let r = 0; r < 4; r++) {
+    if (grid[r].every((s) => s === grid[r][0])) {
+      lines.push([r * 4, r * 4 + 1, r * 4 + 2, r * 4 + 3]);
+    }
+  }
+  // columns
+  for (let c = 0; c < 4; c++) {
+    const col = [grid[0][c], grid[1][c], grid[2][c], grid[3][c]];
+    if (col.every((s) => s === col[0])) {
+      lines.push([c, 4 + c, 8 + c, 12 + c]);
+    }
+  }
+  // diagonals
+  if ([0, 1, 2, 3].every((i) => grid[i][i] === grid[0][0])) {
+    lines.push([0, 5, 10, 15]);
+  }
+  if ([0, 1, 2, 3].every((i) => grid[i][3 - i] === grid[0][3])) {
+    lines.push([3, 6, 9, 12]);
+  }
+  return lines;
+}

--- a/src/utils/rtpTracker.ts
+++ b/src/utils/rtpTracker.ts
@@ -1,0 +1,13 @@
+export class RTPTracker {
+  totalBet = 0;
+  totalWin = 0;
+
+  record(bet: number, win: number) {
+    this.totalBet += bet;
+    this.totalWin += win;
+  }
+
+  get rtp(): number {
+    return this.totalBet === 0 ? 0 : this.totalWin / this.totalBet;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- set up Vite/React project skeleton
- implement SlotGrid and supporting components
- add RTP tracker and win detection utilities
- provide Jest unit tests for `checkWins`
- document limitations due to missing packages

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e23814bf08320857e67a8b32152fd